### PR TITLE
Static title

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -232,7 +232,7 @@ export function createMainWindow() {
         },
         icon: ICON_PATH,
         frame: VencordSettings.store.frameless !== true,
-        ...Settings.store.staticTitle ? { title: "Vencord" } : {},
+        ...(Settings.store.staticTitle ? { title: "Vencord" } : {}),
         ...(VencordSettings.store.macosTranslucency
             ? {
                   vibrancy: "sidebar",

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -76,7 +76,7 @@ function initTray(win: BrowserWindow) {
         trayMenu.items[0].enabled = true;
     });
 
-    win.on('page-title-updated', (e) => e.preventDefault());
+    win.on("page-title-updated", e => e.preventDefault());
 }
 
 function initMenuBar(win: BrowserWindow) {

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -75,6 +75,8 @@ function initTray(win: BrowserWindow) {
     win.on("hide", () => {
         trayMenu.items[0].enabled = true;
     });
+
+    win.on('page-title-updated', (e) => e.preventDefault());
 }
 
 function initMenuBar(win: BrowserWindow) {
@@ -230,6 +232,7 @@ export function createMainWindow() {
             devTools: true,
             preload: join(__dirname, "preload.js")
         },
+        title: "Vencord",
         icon: ICON_PATH,
         frame: VencordSettings.store.frameless !== true,
         ...(VencordSettings.store.macosTranslucency

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -75,8 +75,6 @@ function initTray(win: BrowserWindow) {
     win.on("hide", () => {
         trayMenu.items[0].enabled = true;
     });
-
-    win.on("page-title-updated", e => e.preventDefault());
 }
 
 function initMenuBar(win: BrowserWindow) {
@@ -232,9 +230,9 @@ export function createMainWindow() {
             devTools: true,
             preload: join(__dirname, "preload.js")
         },
-        title: "Vencord",
         icon: ICON_PATH,
         frame: VencordSettings.store.frameless !== true,
+        ...Settings.store.staticTitle ? { title: "Vencord" } : {},
         ...(VencordSettings.store.macosTranslucency
             ? {
                   vibrancy: "sidebar",
@@ -252,6 +250,8 @@ export function createMainWindow() {
 
         return false;
     });
+
+    if (Settings.store.staticTitle) win.on("page-title-updated", e => e.preventDefault());
 
     initWindowBoundsListeners(win);
     if (Settings.store.tray ?? true) initTray(win);

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -31,6 +31,11 @@ export default function SettingsUi() {
             "openLinksWithElectron",
             "Open Links in app (experimental)",
             "Opens links in a new Vencord Desktop window instead of your web browser"
+        ],
+        [
+            "staticTitle",
+            "Static Title",
+            "Makes the window title \"Vencord\" instead of changing to the current page"
         ]
     ];
 

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -32,11 +32,7 @@ export default function SettingsUi() {
             "Open Links in app (experimental)",
             "Opens links in a new Vencord Desktop window instead of your web browser"
         ],
-        [
-            "staticTitle",
-            "Static Title",
-            'Makes the window title "Vencord" instead of changing to the current page'
-        ]
+        ["staticTitle", "Static Title", 'Makes the window title "Vencord" instead of changing to the current page']
     ];
 
     return (

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -35,7 +35,7 @@ export default function SettingsUi() {
         [
             "staticTitle",
             "Static Title",
-            "Makes the window title \"Vencord\" instead of changing to the current page"
+            'Makes the window title "Vencord" instead of changing to the current page'
         ]
     ];
 

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -17,4 +17,5 @@ export interface Settings {
     tray?: boolean;
     minimizeToTray?: boolean;
     skippedUpdate?: string;
+    staticTitle?: boolean;
 }


### PR DESCRIPTION
Changes the main window to use "Vencord" as its title. It's much nicer than having 200 character long window title that changes every-time you navigate