### PR TITLE
 Prevent alt from focusing the menu bar

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -37,7 +37,8 @@ export default function SettingsUi() {
             "Open Links in app (experimental)",
             "Opens links in a new Vencord Desktop window instead of your web browser"
         ],
-        ["staticTitle", "Static Title", 'Makes the window title "Vencord" instead of changing to the current page']
+        ["staticTitle", "Static Title", 'Makes the window title "Vencord" instead of changing to the current page'],
+        ["disableAltMenu", "Disable Alt Menu", "Prevent pressing Alt from showing the menu bar", true]
     ];
 
     return (

--- a/src/renderer/fixes.ts
+++ b/src/renderer/fixes.ts
@@ -10,6 +10,8 @@ import { waitFor } from "@vencord/types/webpack";
 
 import { isFirstRun, localStorage } from "./utils";
 
+import { Settings } from "./settings";
+
 // Make clicking Notifications focus the window
 const originalSetOnClick = Object.getOwnPropertyDescriptor(Notification.prototype, "onclick")!.set!;
 Object.defineProperty(Notification.prototype, "onclick", {
@@ -31,3 +33,12 @@ if (isFirstRun) {
         m.setDesktopType("all");
     });
 }
+
+// Prevent pressing Alt from opening the menu bar
+document.addEventListener("keyup", e => {
+    console.log(e);
+    if (e.key !== "Alt") return;
+    if (!Settings.store.disableAltMenu) return;
+    e.preventDefault();
+});
+

--- a/src/renderer/fixes.ts
+++ b/src/renderer/fixes.ts
@@ -36,7 +36,6 @@ if (isFirstRun) {
 
 // Prevent pressing Alt from opening the menu bar
 document.addEventListener("keyup", e => {
-    console.log(e);
     if (e.key !== "Alt") return;
     if (!Settings.store.disableAltMenu) return;
     e.preventDefault();

--- a/src/shared/settings.d.ts
+++ b/src/shared/settings.d.ts
@@ -18,6 +18,7 @@ export interface Settings {
     minimizeToTray?: boolean;
     skippedUpdate?: string;
     staticTitle?: boolean;
+    disableAltMenu?: boolean;
     arRPC?: boolean;
     appBadge?: boolean;
 


### PR DESCRIPTION
Add a setting (default enabled) that prevents pressing Alt from focusing/showing the menu bar.
Useful for Alt + Clicking to unread message, or for the people like me that fidget and just constantly tap alt