### PR TITLE
fix: improve app hiding functionality

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -274,10 +274,17 @@ function createMainWindow() {
     win.setMenuBarVisibility(false);
 
     win.on("close", e => {
-        if (isQuitting || Settings.store.minimizeToTray === false || Settings.store.tray === false) return;
+        if (
+            isQuitting ||
+            (process.platform !== "darwin" &&
+                (Settings.store.minimizeToTray === false || Settings.store.tray === false))
+        )
+            return;
 
         e.preventDefault();
-        win.hide();
+
+        if (process.platform === "darwin") app.hide();
+        else win.hide();
 
         return false;
     });

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -274,12 +274,8 @@ function createMainWindow() {
     win.setMenuBarVisibility(false);
 
     win.on("close", e => {
-        if (
-            isQuitting ||
-            (process.platform !== "darwin" &&
-                (Settings.store.minimizeToTray === false || Settings.store.tray === false))
-        )
-            return;
+        const useTray = Settings.store.minimizeToTray && Settings.store.tray;
+        if (isQuitting || (process.platform !== "darwin" && !useTray)) return;
 
         e.preventDefault();
 


### PR DESCRIPTION
- Always uses hiding functionality on macOS since the tray doesn't exist and it's the behavior of mainline Discord
- Use `app.hide()` instead of `win.hide()` for built-in activation behavior
